### PR TITLE
Support Bluebird 3.x by getting off deferred usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## What?
 
-This is a simple module that converts supertest's API to return promises if no callback is supplied to the 'end' method. It uses Bluebird 2.0, and the returned promise has all the useful methods thus provided.
+This is a simple module that converts supertest's API to return promises if no callback is supplied to the 'end' method. It uses Bluebird 2.0 or 3.0, and the returned promise has all the useful methods thus provided.
 
-Bluebird and supertest are expected as peerDependencies, but also listed as dev dependencies so that you may use `npm install`. This module was written for Bluebird 2.2.2 and supertest 0.13.0, but the peerDependencies are listed as '*' to avoid dependency mess.
+Bluebird and supertest are expected as peerDependencies, but also listed as dev dependencies so that you may use `npm install`. This module was written for Bluebird 2.2.2 and supertest 0.13.0, but the peerDependencies are listed as '*' to avoid dependency mess. It is safe to use with Bluebird 3.x.
 
 ## How's it work?
 
@@ -14,9 +14,9 @@ Just use supertest as normal, but don't bother supplying a callback to the `end`
 
     var request = ('supertest-promised');
     var app = require('express')();
-    
+
     ...
-    
+
     // assuming mocha
     function validateArrayContents(item) { return item > 0; }
 

--- a/index.js
+++ b/index.js
@@ -22,9 +22,9 @@ proto.end = function (fn) {
     if (typeof fn === 'function') {
         return origEnd.apply(self, arguments);
     }
-    var deferred = Promise.defer();
-    origEnd.call(self, deferred.callback);
-    return deferred.promise;
+    return Promise.fromNode(function(cb) {
+        origEnd.call(self, cb);
+    });
 };
 
 module.exports = request;


### PR DESCRIPTION
Was having issues with Bluebird 3 and this module - using Promise.fromNode (aliased to `fromCallback` in 3.x, but `fromNode` is still available) fixes compatibility with both majors.
